### PR TITLE
Add HUGGING_FACE model support and fix model name filtering based on embeddingProviderType

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
 			<version>0.32.0</version>
 		</dependency>
 
+		<dependency>
+			<groupId>dev.langchain4j</groupId>
+			<artifactId>langchain4j-hugging-face</artifactId>
+			<version>0.32.0</version>
+		</dependency>
+
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-chroma</artifactId>

--- a/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsEmbeddingModelTypeProvider.java
+++ b/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsEmbeddingModelTypeProvider.java
@@ -11,7 +11,7 @@ public class MuleChainVectorsEmbeddingModelTypeProvider implements ValueProvider
 
   @Override
   public Set<Value> resolve() throws ValueResolvingException {
-    return ValueBuilder.getValuesFor("OPENAI", "MISTRAL_AI", "NOMIC"); //"OLLAMA", "COHERE", "AZURE_OPENAI", "HUGGING_FACE";
+    return ValueBuilder.getValuesFor("OPENAI", "MISTRAL_AI", "NOMIC", "HUGGING_FACE"); //"OLLAMA", "COHERE", "AZURE_OPENAI", "HUGGING_FACE";
   }
 
 }

--- a/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsModelParameters.java
+++ b/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsModelParameters.java
@@ -11,7 +11,6 @@ public class MuleChainVectorsModelParameters {
   @Parameter
   @Expression(ExpressionSupport.SUPPORTED)
   @OfValues(MuleChainVectorsParameterEModelNameProvider.class)
-  @Optional(defaultValue = "text-embedding-ada-002")
   private String modelName;
 
   public String getModelName() {

--- a/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsOperations.java
+++ b/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsOperations.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import java.io.File;
 
+import dev.langchain4j.model.huggingface.HuggingFaceEmbeddingModel;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.mule.runtime.extension.api.annotation.Alias;
@@ -171,6 +172,12 @@ public class MuleChainVectorsOperations {
           model = createNomicModel(llmTypeKey, modelParams);
 
         break;
+      case "HUGGING_FACE":
+        llmType = config.getJSONObject("HUGGING_FACE");
+        llmTypeKey = llmType.getString("HUGGING_FACE_API_KEY");
+        model = createHuggingFaceModel(llmTypeKey, modelParams);
+
+        break;
       default:
         throw new IllegalArgumentException("Unsupported Embedding Model: " + configuration.getEmbeddingProviderType());
     }
@@ -201,6 +208,13 @@ public class MuleChainVectorsOperations {
       .logRequests(true)
       .logResponses(true)
       .build();
+  }
+
+  private EmbeddingModel createHuggingFaceModel(String llmTypeKey, MuleChainVectorsModelParameters modelParams) {
+    return HuggingFaceEmbeddingModel.builder()
+            .accessToken(llmTypeKey)
+            .modelId(modelParams.getModelName())
+            .build();
   }
 
 

--- a/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsParameterEModelNameProvider.java
+++ b/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsParameterEModelNameProvider.java
@@ -1,29 +1,53 @@
 package com.mule.mulechain.vectors.internal;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import org.mule.runtime.api.value.Value;
+import org.mule.runtime.extension.api.annotation.param.Config;
 import org.mule.runtime.extension.api.values.ValueBuilder;
 import org.mule.runtime.extension.api.values.ValueProvider;
 import org.mule.runtime.extension.api.values.ValueResolvingException;
 
 public class MuleChainVectorsParameterEModelNameProvider implements ValueProvider {
 
-  private static final Set<Value> VALUES_FOR = ValueBuilder.getValuesFor(
+  @Config
+  private MuleChainVectorsConfiguration configuration;
+
+  private static final Set<Value> VALUES_FOR_OPENAI = ValueBuilder.getValuesFor(
           "text-embedding-3-small",
           "text-embedding-3-large",
-          "text-embedding-ada-002",
-          "mistral-embed",
-          "all-minilm",
-          "nomic-embed-text",
-          "tiiuae/falcon-7b-instruct",
-          "sentence-transformers/all-MiniLM-L6-v2"
+          "text-embedding-ada-002"
+  );
+
+  private static final Set<Value> VALUES_FOR_MISTRAL_AI = ValueBuilder.getValuesFor(
+          "mistral-embed"
+  );
+
+  private static final Set<Value> VALUES_FOR_NOMIC = ValueBuilder.getValuesFor(
+          "nomic-embed-text"
+  );
+
+  private static final Set<Value> VALUES_FOR_HUGGING_FACE = ValueBuilder.getValuesFor(
+            "tiiuae/falcon-7b-instruct",
+            "sentence-transformers/all-MiniLM-L6-v2"
   );
 
   @Override
   public Set<Value> resolve() throws ValueResolvingException {
-
-
-    return VALUES_FOR;
+    String embeddingProviderType = configuration.getEmbeddingProviderType();
+    switch (embeddingProviderType) {
+      case "OPENAI":
+        return VALUES_FOR_OPENAI;
+      case "MISTRAL_AI":
+        return VALUES_FOR_MISTRAL_AI;
+      case "NOMIC":
+        return VALUES_FOR_NOMIC;
+      case "HUGGING_FACE":
+        return VALUES_FOR_HUGGING_FACE;
+      default:
+        return Collections.emptySet();
+    }
   }
 
 }

--- a/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsParameterEModelNameProvider.java
+++ b/src/main/java/com/mule/mulechain/vectors/internal/MuleChainVectorsParameterEModelNameProvider.java
@@ -9,12 +9,14 @@ import org.mule.runtime.extension.api.values.ValueResolvingException;
 public class MuleChainVectorsParameterEModelNameProvider implements ValueProvider {
 
   private static final Set<Value> VALUES_FOR = ValueBuilder.getValuesFor(
-    "text-embedding-3-small",
-    "text-embedding-3-large",
-    "text-embedding-ada-002",
-    "mistral-embed",
-    "all-minilm",
-    "nomic-embed-text"
+          "text-embedding-3-small",
+          "text-embedding-3-large",
+          "text-embedding-ada-002",
+          "mistral-embed",
+          "all-minilm",
+          "nomic-embed-text",
+          "tiiuae/falcon-7b-instruct",
+          "sentence-transformers/all-MiniLM-L6-v2"
   );
 
   @Override


### PR DESCRIPTION
This pull request addresses two main changes in the custom Mule connector:

1. Add support for HUGGING_FACE model: Implemented support for the HUGGING_FACE model to extend the connector's capabilities.
2. Fix model name filtering based on embeddingProviderType: Fixed an issue where all model names were displayed regardless of the selected embeddingProviderType configuration. This fix ensures that only relevant model names are shown, based on the provider selected in the connector configuration (OPENAI, MISTRAL_AI, NOMIC, HUGGING_FACE), preventing potential failures and confusion during operation.

Manually tested by selecting each embeddingProviderType and verifying that only relevant model names were displayed in the configuration. Ensured that operations execute successfully with the correct models based on the selected provider.